### PR TITLE
feat: Add Opus 4.6 model detection

### DIFF
--- a/claude-pulse
+++ b/claude-pulse
@@ -16,6 +16,10 @@ model_id=$(echo "$input" | jq -r '.model.id // "claude-sonnet-4-5-20250929"')
 
 # Convert model ID to friendly name
 case "$model_id" in
+    claude-opus-4-6*)
+        model_name="Opus 4.6"
+        context_limit=200000
+        ;;
     claude-opus-4*)
         model_name="Opus 4.5"
         context_limit=200000

--- a/claude-pulse.ps1
+++ b/claude-pulse.ps1
@@ -13,6 +13,7 @@ $model_id = if ($data.model.id) { $data.model.id } else { "claude-sonnet-4-5-202
 
 # Convert model ID to friendly name
 $model_name = switch -Wildcard ($model_id) {
+    "claude-opus-4-6*" { "Opus 4.6"; break }
     "claude-opus-4*" { "Opus 4.5"; break }
     "claude-sonnet-4*" { "Sonnet 4.5"; break }
     "claude-haiku-3-5*" { "Haiku 3.5"; break }


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-6*` pattern before the generic `claude-opus-4*` case in both bash and PowerShell scripts
- Opus 4.6 now displays as "Opus 4.6" instead of incorrectly showing "Opus 4.5"
- 1M context window already handled by existing dynamic detection (reads `context_window_size` from JSON input)

## Test plan
- [x] Opus 4.6 detected: `🧠 55k/200k (28%) · 🤖 Opus 4.6 📁 /test`
- [x] Opus 4.5 still works: `🧠 55k/200k (28%) · 🤖 Opus 4.5 📁 /test`
- [x] 1M context displays correctly: `🧠 505k/1000k (50%) · 🤖 Opus 4.6 📁 /test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)