### PR TITLE
fix: Detect compact_boundary to prevent stale token % after compaction

### DIFF
--- a/claude-pulse
+++ b/claude-pulse
@@ -67,12 +67,13 @@ if [[ -f "$transcript_path" ]]; then
         reverse_cmd="tail -r"
     fi
     input_tokens=$($reverse_cmd "$transcript_path" 2>/dev/null | jq --arg sid "$session_id" -s '
-        map(select(.sessionId == $sid and .message.usage)) |
-        if length > 0 then
+        map(select(.sessionId == $sid and ((.message.usage) or (.subtype == "compact_boundary")))) |
+        if length == 0 then null
+        elif .[0].subtype == "compact_boundary" then null
+        elif .[0].message.usage then
             .[0].message.usage |
             ((.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0))
-        else
-            null
+        else null
         end
     ' 2>/dev/null)
 fi

--- a/claude-pulse.ps1
+++ b/claude-pulse.ps1
@@ -40,11 +40,16 @@ if ($null -ne $data.context_window -and $null -ne $data.context_window.context_w
 if ($data.transcript_path -and (Test-Path $data.transcript_path)) {
     $session_id = $data.session_id
     $lines = Get-Content $data.transcript_path | ForEach-Object { $_ | ConvertFrom-Json }
-    $usage = $lines | Where-Object { $_.sessionId -eq $session_id -and $_.message.usage } | Select-Object -Last 1
-    if ($usage) {
-        $u = $usage.message.usage
+    # Filter to entries with usage or compact_boundary markers, then check the most recent
+    $relevant = $lines | Where-Object {
+        $_.sessionId -eq $session_id -and (($_.message.usage) -or ($_.subtype -eq "compact_boundary"))
+    }
+    $last = $relevant | Select-Object -Last 1
+    if ($last -and $last.subtype -ne "compact_boundary" -and $last.message.usage) {
+        $u = $last.message.usage
         $input_tokens = ($u.input_tokens ?? 0) + ($u.cache_creation_input_tokens ?? 0) + ($u.cache_read_input_tokens ?? 0)
     }
+    # If last relevant entry is compact_boundary, skip transcript (stale) — fall through to context_window
 }
 
 # Fallback: Native context_window (conversation only, missing MCP/system overhead)


### PR DESCRIPTION
## Summary
- After `/compact` or auto-compaction, the transcript retains old entries with pre-compaction token counts
- The statusline was picking up these stale values, showing wildly inflated percentages (e.g. 648%)
- Now checks if a `compact_boundary` marker is more recent than the last usage entry, and falls through to `context_window` data which is accurate post-compaction
- Fixed in both bash (`claude-pulse`) and PowerShell (`claude-pulse.ps1`)

## Test plan
- [ ] Run `/compact` in a session, verify statusline shows correct percentage immediately after
- [ ] Resume a compacted session, verify percentage is accurate
- [ ] Verify normal (non-compacted) sessions still show correct billing API tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)