### PR TITLE
feat: Show context window size in status line (200k/1M)

### DIFF
--- a/claude-pulse
+++ b/claude-pulse
@@ -56,6 +56,13 @@ if [[ "$actual_limit" != "null" ]] && [[ -n "$actual_limit" ]]; then
     context_limit="$actual_limit"
 fi
 
+# Format context limit for display (200000 → "200k", 1000000 → "1M")
+if (( context_limit >= 1000000 )) && (( context_limit % 1000000 == 0 )); then
+    context_label="$((context_limit / 1000000))M"
+else
+    context_label="$((context_limit / 1000))k"
+fi
+
 # Primary: Billing API from transcript (includes ALL context: messages + system + MCP tools)
 # Sum: input_tokens + cache_creation_input_tokens + cache_read_input_tokens
 # This matches what /context shows
@@ -294,4 +301,4 @@ if [[ -n "$branch" ]]; then
 fi
 
 # Output format: "🧠 [████░░] 72% · 🤖 Model · 💬 Topic · 🌿 branch 📁 /path"
-printf "${color}🧠 ${bar} ${percent}%%${reset} · 🤖 ${model_name}${name_segment}${pr_segment} 📁 ${cwd}"
+printf "${color}🧠 ${bar} ${percent}%%${reset} · 🤖 ${model_name} (${context_label})${name_segment}${pr_segment} 📁 ${cwd}"

--- a/claude-pulse.ps1
+++ b/claude-pulse.ps1
@@ -34,6 +34,13 @@ if ($null -ne $data.context_window -and $null -ne $data.context_window.context_w
     $context_limit = $data.context_window.context_window_size
 }
 
+# Format context limit for display (200000 → "200k", 1000000 → "1M")
+if ($context_limit -ge 1000000 -and $context_limit % 1000000 -eq 0) {
+    $context_label = "$([math]::Floor($context_limit / 1000000))M"
+} else {
+    $context_label = "$([math]::Floor($context_limit / 1000))k"
+}
+
 # Primary: Billing API from transcript (includes ALL context: messages + system + MCP tools)
 # Sum: input_tokens + cache_creation_input_tokens + cache_read_input_tokens
 # This matches what /context shows
@@ -288,4 +295,4 @@ if ($branch) {
 }
 
 # Output format: "🧠 [████░░] 72% · 🤖 Model · 💬 Topic · 🌿 branch 📁 /path"
-Write-Host "${color}🧠 $bar ${percent}%${reset} · 🤖 ${model_name}${name_segment}${pr_segment} 📁 $cwd"
+Write-Host "${color}🧠 $bar ${percent}%${reset} · 🤖 ${model_name} (${context_label})${name_segment}${pr_segment} 📁 $cwd"


### PR DESCRIPTION
## Summary
- Adds human-readable context window label (`200k`, `1M`) next to model name in the status line
- Enables distinguishing standard vs extended context sessions at a glance
- Applied to both bash and PowerShell versions

**Before:** `🤖 Opus 4.6`
**After:** `🤖 Opus 4.6 (1M)` or `🤖 Opus 4.6 (200k)`

## Test plan
- [x] Verified with 200k context input → shows `(200k)`
- [x] Verified with 1M context input → shows `(1M)`
- [x] Installed to statusline and confirmed live display

🤖 Generated with [Claude Code](https://claude.com/claude-code)