### PR TITLE
fix: shorten alert indicators in minimal density mode

### DIFF
--- a/claude-pulse
+++ b/claude-pulse
@@ -759,14 +759,26 @@ if [[ -n "$RED_ALERT_CITIES" ]] || [[ -n "$RED_ALERT_MODE" ]]; then
         if [[ -n "$_expected_ver" ]] && [[ -n "$_running_ver" ]] && [[ "$_running_ver" != "$_expected_ver" ]]; then
             # Version mismatch — drop restart marker for SessionStart hook to pick up
             echo "$_expected_ver" > "$_restart_request" 2>/dev/null
-            alert_indicator="${C_YELLOW}🟡 Daemon v${_running_ver} (update pending)${_debug_suffix}${reset}"
+            if [[ "$density" == "minimal" ]]; then
+                alert_indicator="${C_YELLOW}🟡${_debug_suffix}${reset}"
+            else
+                alert_indicator="${C_YELLOW}🟡 Daemon v${_running_ver} (update pending)${_debug_suffix}${reset}"
+            fi
         elif [[ -z "$alert_segment" ]]; then
-            alert_indicator="${C_GREEN}🟢 Alerts daemon ON${_debug_suffix}${reset}"
+            if [[ "$density" == "minimal" ]]; then
+                alert_indicator="${C_GREEN}🟢${_debug_suffix}${reset}"
+            else
+                alert_indicator="${C_GREEN}🟢 Alerts daemon ON${_debug_suffix}${reset}"
+            fi
         fi
     else
         # Daemon not running — drop restart marker (hook or update.sh will handle it)
         touch "$_restart_request" 2>/dev/null
-        alert_indicator="${C_GRAY}🔕 Alerts daemon not running${_debug_suffix}${reset}"
+        if [[ "$density" == "minimal" ]]; then
+            alert_indicator="${C_GRAY}🔕${_debug_suffix}${reset}"
+        else
+            alert_indicator="${C_GRAY}🔕 Alerts daemon not running${_debug_suffix}${reset}"
+        fi
     fi
 fi
 

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -209,6 +209,21 @@ assert_not_contains "$_min_alert" "Alerts daemon ON" "minimal: no 'Alerts daemon
 _reg_alert=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
 assert_contains "$_reg_alert" "🟢 Alerts daemon ON" "regular: shows full daemon ON text"
 
+# test_minimal_version_mismatch: daemon running but version differs → just 🟡 emoji
+export RED_ALERT_STATE_DIR="$TEST_TMPDIR"
+echo "0.0.0" > "${TEST_TMPDIR}/daemon_version"
+setup_mock_daemon
+setup_expired_state "1" '["תל אביב"]'
+_min_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)
+assert_contains "$_min_mismatch" "🟡" "minimal: shows yellow circle for version mismatch"
+assert_not_contains "$_min_mismatch" "update pending" "minimal: no 'update pending' text"
+
+# test_regular_version_mismatch: same in regular → full text
+_reg_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
+assert_contains "$_reg_mismatch" "🟡 Daemon v0.0.0 (update pending)" "regular: shows full version mismatch text"
+rm -f "${TEST_TMPDIR}/daemon_version"
+unset RED_ALERT_STATE_DIR
+
 # test_minimal_daemon_not_running: daemon not running → just 🔕 emoji
 rm -f "$RED_ALERT_PID_FILE"
 _min_off=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -191,5 +191,35 @@ assert_not_contains "$_heavy_clean_line1" "    " "heavy mode: no large gap on li
 
 rm -rf "$_diff_dir" "$_clean_dir"
 
+# --- Minimal mode alert indicator tests ---
+echo ""
+echo "Testing minimal mode alert indicators..."
+
+# Set up mock daemon (PID file pointing to our process)
+setup_mock_daemon
+export RED_ALERT_CITIES="Tel Aviv"
+
+# test_minimal_alert_on: daemon running, no active alert → just 🟢 emoji
+setup_expired_state "1" '["תל אביב"]'
+_min_alert=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)
+assert_contains "$_min_alert" "🟢" "minimal: shows green circle"
+assert_not_contains "$_min_alert" "Alerts daemon ON" "minimal: no 'Alerts daemon ON' text"
+
+# test_regular_alert_on: same scenario in regular → shows full text
+_reg_alert=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
+assert_contains "$_reg_alert" "🟢 Alerts daemon ON" "regular: shows full daemon ON text"
+
+# test_minimal_daemon_not_running: daemon not running → just 🔕 emoji
+rm -f "$RED_ALERT_PID_FILE"
+_min_off=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)
+assert_contains "$_min_off" "🔕" "minimal: shows muted bell"
+assert_not_contains "$_min_off" "not running" "minimal: no 'not running' text"
+
+# test_regular_daemon_not_running: same in regular → full text
+_reg_off=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
+assert_contains "$_reg_off" "🔕 Alerts daemon not running" "regular: shows full not running text"
+
+unset RED_ALERT_CITIES
+
 cleanup
 report

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -210,18 +210,23 @@ _reg_alert=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_wind
 assert_contains "$_reg_alert" "🟢 Alerts daemon ON" "regular: shows full daemon ON text"
 
 # test_minimal_version_mismatch: daemon running but version differs → just 🟡 emoji
+# Stage a fake HOME with red-alert-daemon.sh so _expected_ver parses hermetically
+_fake_home="${TEST_TMPDIR}/fakehome"
+mkdir -p "${_fake_home}/.claude"
+echo -e '#!/bin/bash\n# red-alert-daemon.sh v9.9.9: fake' > "${_fake_home}/.claude/red-alert-daemon.sh"
 export RED_ALERT_STATE_DIR="$TEST_TMPDIR"
 echo "0.0.0" > "${TEST_TMPDIR}/daemon_version"
 setup_mock_daemon
 setup_expired_state "1" '["תל אביב"]'
-_min_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)
+_min_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | HOME="$_fake_home" CLAUDE_PULSE_DENSITY=minimal "$PULSE" 2>/dev/null)
 assert_contains "$_min_mismatch" "🟡" "minimal: shows yellow circle for version mismatch"
 assert_not_contains "$_min_mismatch" "update pending" "minimal: no 'update pending' text"
 
 # test_regular_version_mismatch: same in regular → full text
-_reg_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
+_reg_mismatch=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | HOME="$_fake_home" CLAUDE_PULSE_DENSITY=regular "$PULSE" 2>/dev/null)
 assert_contains "$_reg_mismatch" "🟡 Daemon v0.0.0 (update pending)" "regular: shows full version mismatch text"
 rm -f "${TEST_TMPDIR}/daemon_version"
+rm -rf "$_fake_home"
 unset RED_ALERT_STATE_DIR
 
 # test_minimal_daemon_not_running: daemon not running → just 🔕 emoji


### PR DESCRIPTION
## Summary
- Show only emoji (🟢/🔕/🟡) for daemon status indicators in minimal density mode
- Full text ("Alerts daemon ON", "Alerts daemon not running", "Daemon vX.Y (update pending)") preserved for regular and heavy modes
- Saves horizontal space on narrow terminals (<100 cols)

## Test plan
- [x] All 169 tests pass (`bash tests/run_tests.sh`)
- [ ] Manual: `CLAUDE_PULSE_DENSITY=minimal RED_ALERT_CITIES="Tel Aviv"` — verify `🟢` only
- [ ] Manual: `CLAUDE_PULSE_DENSITY=regular RED_ALERT_CITIES="Tel Aviv"` — verify full text unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)