### PR TITLE
fix: Opus 4.7 & Haiku 4.5 model detection (v3.1.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ Shows uncommitted changes (staged + unstaged) via `LC_ALL=C git diff HEAD --shor
 ### Model detection
 
 - Model patterns must be ordered **most specific first** in the case/switch block (e.g., `claude-opus-4-6*` before `claude-opus-4*`), otherwise more specific models match the generic pattern
-- Currently supported: Opus 4.6, Opus 4.5, Sonnet 4.5, Sonnet 3.7, Sonnet 3.5, Haiku 3.5, Opus 3
+- Currently supported: Opus 4.7, Opus 4.6, Opus 4.5, Sonnet 4.6, Sonnet 4.5, Sonnet 3.7, Sonnet 3.5, Haiku 4.5, Haiku 3.5, Opus 3
+- **Not exposed by Claude Code statusline JSON** (as of 2.1.114): thinking/effort level (`/effort low|medium|high|xhigh|max`). There's no reliable way to display it until Claude Code adds it to the stdin payload — see https://github.com/anthropics/claude-code/issues/31987.
 
 ### Conversation name feature
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-pulse
 
-> Real-time token usage monitoring for Claude Code status line | **v3.1.2**
+> Real-time token usage monitoring for Claude Code status line | **v3.1.3**
 
 **claude-pulse** displays your current Claude Code token usage directly in your status line, helping you stay aware of context consumption without running `/context` manually.
 
@@ -149,10 +149,12 @@ The script:
 
 ## Supported Models
 
+- Claude Opus 4.7 (200k default, 1M with extended context)
 - Claude Opus 4.6 (200k default, 1M with extended context)
 - Claude Opus 4.5 (200k context)
 - Claude Sonnet 4.x (200k context)
 - Claude 3.5 Sonnet (200k context)
+- Claude Haiku 4.5 (200k context)
 - Claude Haiku 3.5 (200k context)
 - Unknown models default to 200k
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## v3.1.3 - Opus 4.7 & Haiku 4.5 Support
+
+**Released:** April 18, 2026
+
+### Bug Fixes
+
+- **Opus 4.7 misidentified as "Opus 4.5"** — the generic `claude-opus-4*` case pattern was shadowing the newer model. Added a more specific `claude-opus-4-7*` case above it. Patterns are now documented as "most-specific first".
+- **Haiku 4.5 not recognized** — previously fell through to the generic "Claude" fallback. Added `claude-haiku-4-5*` / `claude-4-5-haiku*` patterns.
+
+### Not Included
+
+- **Thinking/effort level display** — Claude Code 2.1.114 does not expose the current `/effort` level (`low`/`medium`/`high`/`xhigh`/`max`) in the statusline stdin JSON. Tracking upstream at [anthropics/claude-code#31987](https://github.com/anthropics/claude-code/issues/31987); will wire it up once the field lands.
+
+### Tests
+
+- 4 new entries in the model-detection matrix for `claude-opus-4-7*` and `claude-haiku-4-5*`
+- Regression assertion that Opus 4.7 output never contains "Opus 4.5" or "Opus 4.6"
+
 ## v3.1.2 - Minimal Mode Polish
 
 **Released:** April 5, 2026

--- a/claude-pulse
+++ b/claude-pulse
@@ -1,5 +1,5 @@
 #!/bin/bash
-# claude-pulse v3.1.2: Real-time token usage for Claude Code status line
+# claude-pulse v3.1.3: Real-time token usage for Claude Code status line
 # Uses billing API (transcript) for accurate FULL context usage
 # Falls back to native context_window when transcript unavailable
 # Displays current model name and AI-generated conversation names
@@ -56,7 +56,13 @@ fi
 short_cwd="$(basename "$cwd")"
 
 # Convert model ID to friendly name
+# Patterns are ordered most-specific first — a shorter pattern higher up would
+# shadow a more specific one (e.g. claude-opus-4* would catch claude-opus-4-7).
 case "$model_id" in
+    claude-opus-4-7*)
+        model_name="Opus 4.7"; model_short="Op4.7"
+        context_limit=200000
+        ;;
     claude-opus-4-6*)
         model_name="Opus 4.6"; model_short="Op4.6"
         context_limit=200000
@@ -75,6 +81,10 @@ case "$model_id" in
         ;;
     claude-sonnet-4*)
         model_name="Sonnet 4.5"; model_short="Son4.5"
+        context_limit=200000
+        ;;
+    claude-haiku-4-5*|claude-4-5-haiku*)
+        model_name="Haiku 4.5"; model_short="Hai4.5"
         context_limit=200000
         ;;
     claude-haiku-3-5*|claude-3-5-haiku*)

--- a/claude-pulse.ps1
+++ b/claude-pulse.ps1
@@ -1,4 +1,4 @@
-# claude-pulse.ps1 v3.1.2: Real-time token usage for Claude Code status line (Windows)
+# claude-pulse.ps1 v3.1.3: Real-time token usage for Claude Code status line (Windows)
 # Uses billing API (transcript) for accurate FULL context usage
 # Falls back to native context_window when transcript unavailable
 # Displays current model name and AI-generated conversation names
@@ -11,13 +11,18 @@ $data = $inputJson | ConvertFrom-Json
 $cwd = $data.cwd
 $model_id = if ($data.model.id) { $data.model.id } else { "claude-sonnet-4-5-20250929" }
 
-# Convert model ID to friendly name
+# Convert model ID to friendly name.
+# Ordered most-specific first: a shorter pattern (e.g. claude-opus-4*) would
+# otherwise shadow newer families like claude-opus-4-7.
 $model_name = switch -Wildcard ($model_id) {
+    "claude-opus-4-7*" { "Opus 4.7"; break }
     "claude-opus-4-6*" { "Opus 4.6"; break }
     "claude-opus-4*" { "Opus 4.5"; break }
     "claude-sonnet-4-6*" { "Sonnet 4.6"; break }
     "claude-sonnet-4-5*" { "Sonnet 4.5"; break }
     "claude-sonnet-4*" { "Sonnet 4.5"; break }
+    "claude-haiku-4-5*" { "Haiku 4.5"; break }
+    "claude-4-5-haiku*" { "Haiku 4.5"; break }
     "claude-haiku-3-5*" { "Haiku 3.5"; break }
     "claude-3-5-haiku*" { "Haiku 3.5"; break }
     "claude-sonnet-3-5*" { "Sonnet 3.5"; break }

--- a/red-alert-daemon.sh
+++ b/red-alert-daemon.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# red-alert-daemon.sh v3.1.2: Background daemon for Pikud HaOref alert monitoring
+# red-alert-daemon.sh v3.1.3: Background daemon for Pikud HaOref alert monitoring
 # Polls the official alert API every 2 seconds and writes state to disk
 # Supports: normal mode (API), all mode (API, no filter), mock mode (offline testing)
 

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -22,6 +22,8 @@ assert_contains "$output" "test" "basic output has cwd"
 
 # test_model_detection: each model ID maps to correct name
 for pair in \
+    "claude-opus-4-7-20260401:Opus 4.7" \
+    "claude-opus-4-7:Opus 4.7" \
     "claude-opus-4-6-20250929:Opus 4.6" \
     "claude-opus-4-6:Opus 4.6" \
     "claude-opus-4-20250512:Opus 4.5" \
@@ -29,6 +31,9 @@ for pair in \
     "claude-sonnet-4-6:Sonnet 4.6" \
     "claude-sonnet-4-5-20250514:Sonnet 4.5" \
     "claude-sonnet-4-20250514:Sonnet 4.5" \
+    "claude-haiku-4-5-20251001:Haiku 4.5" \
+    "claude-haiku-4-5:Haiku 4.5" \
+    "claude-4-5-haiku-20260101:Haiku 4.5" \
     "claude-haiku-3-5-20241022:Haiku 3.5" \
     "claude-sonnet-3-5-20240620:Sonnet 3.5" \
     "claude-opus-3-20240229:Opus 3" \
@@ -38,6 +43,11 @@ for pair in \
     out=$(echo "{\"cwd\":\"/test\",\"model\":{\"id\":\"$model_id\"},\"context_window\":{\"total_input_tokens\":50000,\"total_output_tokens\":5000,\"context_window_size\":200000}}" | "$PULSE" 2>/dev/null)
     assert_contains "$out" "$expected_name" "model detection: $model_id → $expected_name"
 done
+
+# Regression: Opus 4.7 must not fall through to the generic claude-opus-4* pattern and show "Opus 4.5".
+out_opus47=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-7-20260401"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":1000000}}' | "$PULSE" 2>/dev/null)
+assert_not_contains "$out_opus47" "Opus 4.5" "Opus 4.7 does not fall through to Opus 4.5"
+assert_not_contains "$out_opus47" "Opus 4.6" "Opus 4.7 does not fall through to Opus 4.6"
 
 # test_context_limit_format: 200000 → "200k", 1000000 → "1M"
 out_200k=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | "$PULSE" 2>/dev/null)

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# claude-pulse update.sh v3.1.2: OTA update manager
+# claude-pulse update.sh v3.1.3: OTA update manager
 # Checks GitHub releases, downloads, validates, and applies updates atomically
 # Triggered by SessionStart hook — runs in background, singleton-locked
 


### PR DESCRIPTION
## Summary
- Opus 4.7 was rendering as "Opus 4.5" — `claude-opus-4-7` fell through the generic `claude-opus-4*` pattern. Fixed by adding a more specific `claude-opus-4-7*` branch above it in both `claude-pulse` (bash) and `claude-pulse.ps1`.
- Haiku 4.5 was unrecognized and fell through to the generic "Claude" label. Added `claude-haiku-4-5*|claude-4-5-haiku*` patterns.
- Thinking/effort level (`/effort low|medium|high|xhigh|max`) is **not** in scope: Claude Code 2.1.114 does not expose it in the statusline stdin JSON. Noted in `CLAUDE.md` and `RELEASE.md`, tracking upstream at anthropics/claude-code#31987.

## Version bump
v3.1.2 → v3.1.3 in: `claude-pulse`, `claude-pulse.ps1`, `red-alert-daemon.sh`, `update.sh`, plus `README.md` and `RELEASE.md`.

## Test plan
- [x] `bash tests/run_tests.sh` — all 67 tests pass
- [x] Added matrix rows for `claude-opus-4-7`, `claude-opus-4-7-20260401`, `claude-haiku-4-5`, `claude-haiku-4-5-20251001`, `claude-4-5-haiku-20260101`
- [x] Regression assertion: Opus 4.7 output never contains "Opus 4.5" or "Opus 4.6"
- [x] Smoke-tested both new IDs end-to-end in minimal density — render as `Op4.7(1M)` and `Hai4.5(200k)`
- [x] Codex review clean (LGTM with minor notes — the one actionable test-row suggestion is included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)