### PR TITLE
feat: generic model detection (+ Opus 4.8)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    # macOS runner matches the script's real target: bash 3.2 + BSD tooling
+    # (the suite uses BSD `sed -i ''` and `tail -r`, which differ on Linux).
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure jq
+        run: command -v jq >/dev/null 2>&1 || brew install jq
+
+      - name: Run test suite
+        run: bash tests/run_tests.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,10 @@ Shows uncommitted changes (staged + unstaged) via `LC_ALL=C git diff HEAD --shor
 
 ### Model detection
 
-- Model patterns must be ordered **most specific first** in the case/switch block (e.g., `claude-opus-4-6*` before `claude-opus-4*`), otherwise more specific models match the generic pattern
-- Currently supported: Opus 4.7, Opus 4.6, Opus 4.5, Sonnet 4.6, Sonnet 4.5, Sonnet 3.7, Sonnet 3.5, Haiku 4.5, Haiku 3.5, Opus 3
+- **Generic-first parsing (no per-model maintenance)**: modern IDs follow `claude-<family>-<major>-<minor>` and are parsed by one regex (`^claude-(opus|sonnet|haiku)-([0-9]+)-([0-9]+)`), so new releases (Opus 4.8, a future Sonnet 5.0, …) are recognized with **zero code changes**. A ≤2-digit minor guard (bash) / `(?![0-9])` lookahead (PowerShell) rejects 8-digit release dates like `claude-opus-4-20250512` so they don't read as "Opus 4.20250512".
+- **Legacy table** handles only irregular IDs the parser can't: version-first names (`claude-3-5-sonnet`, `claude-4-5-haiku`), no-minor base-4 models (`claude-opus-4*` → "Opus 4.5", `claude-sonnet-4*` → "Sonnet 4.5"), and `claude-opus-3`/`claude-3-opus` → "Opus 3", `claude-3-7-sonnet` → "Sonnet 3.7".
+- **Unknown IDs** fall back to Claude Code's own `model.display_name` from the statusline JSON (it already computes a friendly name), and only then to the literal "Claude".
+- Recognized today: Opus 4.8, Opus 4.7, Opus 4.6, Opus 4.5, Sonnet 4.6, Sonnet 4.5, Sonnet 3.7, Sonnet 3.5, Haiku 4.5, Haiku 3.5, Opus 3 — plus any future modern-scheme release automatically.
 - **Not exposed by Claude Code statusline JSON** (as of 2.1.114): thinking/effort level (`/effort low|medium|high|xhigh|max`). There's no reliable way to display it until Claude Code adds it to the stdin payload — see https://github.com/anthropics/claude-code/issues/31987.
 
 ### Conversation name feature

--- a/README.md
+++ b/README.md
@@ -149,14 +149,17 @@ The script:
 
 ## Supported Models
 
-- Claude Opus 4.7 (200k default, 1M with extended context)
-- Claude Opus 4.6 (200k default, 1M with extended context)
+Modern model IDs (`claude-<family>-<major>-<minor>`) are parsed generically, so
+new releases like Opus 4.8 are recognized automatically — no update required.
+
+- Claude Opus 4.8 (200k default, 1M with extended context)
+- Claude Opus 4.7 / 4.6 (200k default, 1M with extended context)
 - Claude Opus 4.5 (200k context)
 - Claude Sonnet 4.x (200k context)
 - Claude 3.5 Sonnet (200k context)
 - Claude Haiku 4.5 (200k context)
 - Claude Haiku 3.5 (200k context)
-- Unknown models default to 200k
+- Unknown models fall back to Claude Code's own `display_name`, else default to 200k
 
 ## Configuration
 

--- a/claude-pulse
+++ b/claude-pulse
@@ -55,59 +55,56 @@ fi
 # CWD shortening — basename for all densities (full path overflows terminal)
 short_cwd="$(basename "$cwd")"
 
-# Convert model ID to friendly name
-# Patterns are ordered most-specific first — a shorter pattern higher up would
-# shadow a more specific one (e.g. claude-opus-4* would catch claude-opus-4-7).
-case "$model_id" in
-    claude-opus-4-7*)
-        model_name="Opus 4.7"; model_short="Op4.7"
-        context_limit=200000
-        ;;
-    claude-opus-4-6*)
-        model_name="Opus 4.6"; model_short="Op4.6"
-        context_limit=200000
-        ;;
-    claude-opus-4*)
-        model_name="Opus 4.5"; model_short="Op4.5"
-        context_limit=200000
-        ;;
-    claude-sonnet-4-6*)
-        model_name="Sonnet 4.6"; model_short="Son4.6"
-        context_limit=200000
-        ;;
-    claude-sonnet-4-5*)
-        model_name="Sonnet 4.5"; model_short="Son4.5"
-        context_limit=200000
-        ;;
-    claude-sonnet-4*)
-        model_name="Sonnet 4.5"; model_short="Son4.5"
-        context_limit=200000
-        ;;
-    claude-haiku-4-5*|claude-4-5-haiku*)
-        model_name="Haiku 4.5"; model_short="Hai4.5"
-        context_limit=200000
-        ;;
-    claude-haiku-3-5*|claude-3-5-haiku*)
-        model_name="Haiku 3.5"; model_short="Hai3.5"
-        context_limit=200000
-        ;;
-    claude-sonnet-3-5*|claude-3-5-sonnet*)
-        model_name="Sonnet 3.5"; model_short="Son3.5"
-        context_limit=200000
-        ;;
-    claude-opus-3*|claude-3-opus*)
-        model_name="Opus 3"; model_short="Op3"
-        context_limit=200000
-        ;;
-    claude-sonnet-3-7*|claude-3-7-sonnet*)
-        model_name="Sonnet 3.7"; model_short="Son3.7"
-        context_limit=200000
-        ;;
-    *)
-        model_name="Claude"; model_short="Claude"
-        context_limit=200000
-        ;;
-esac
+# Convert model ID to friendly name.
+#
+# The modern naming scheme is regular — claude-<family>-<major>-<minor> — so we
+# parse it generically and NEVER need a new branch per release (Opus 4.8, a
+# future Sonnet 5.0, etc. all "just work"). Only the irregular legacy IDs
+# (version-first, no-minor base models, Opus 3) need explicit rows below, and
+# anything truly unknown defers to Claude Code's own model.display_name.
+context_limit=200000
+model_name=""; model_short=""
+
+if [[ "$model_id" =~ ^claude-(opus|sonnet|haiku)-([0-9]+)-([0-9]+) ]] \
+   && [[ ${#BASH_REMATCH[3]} -le 2 ]]; then
+    # Modern scheme. The ≤2-digit minor guard rejects 8-digit release dates
+    # (e.g. claude-opus-4-20250512), letting those fall through to legacy.
+    case "${BASH_REMATCH[1]}" in
+        opus)   model_name="Opus";   model_short="Op"  ;;
+        sonnet) model_name="Sonnet"; model_short="Son" ;;
+        haiku)  model_name="Haiku";  model_short="Hai" ;;
+    esac
+    model_name="$model_name ${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+    model_short="$model_short${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+fi
+
+if [[ -z "$model_name" ]]; then
+    # Legacy / irregular IDs only — modern releases are handled above.
+    case "$model_id" in
+        claude-opus-4*)
+            model_name="Opus 4.5"; model_short="Op4.5" ;;
+        claude-sonnet-4*)
+            model_name="Sonnet 4.5"; model_short="Son4.5" ;;
+        claude-4-5-haiku*)
+            model_name="Haiku 4.5"; model_short="Hai4.5" ;;
+        claude-3-5-haiku*)
+            model_name="Haiku 3.5"; model_short="Hai3.5" ;;
+        claude-3-5-sonnet*)
+            model_name="Sonnet 3.5"; model_short="Son3.5" ;;
+        claude-opus-3*|claude-3-opus*)
+            model_name="Opus 3"; model_short="Op3" ;;
+        claude-3-7-sonnet*)
+            model_name="Sonnet 3.7"; model_short="Son3.7" ;;
+        *)
+            # Unknown ID — defer to Claude Code's own friendly name if present.
+            if [[ -n "$display_name" ]]; then
+                model_name="$display_name"; model_short="$display_name"
+            else
+                model_name="Claude"; model_short="Claude"
+            fi
+            ;;
+    esac
+fi
 
 # Check for actual context window size from JSON (overrides hardcoded defaults)
 actual_limit=$(echo "$input" | jq -r '.context_window.context_window_size // null')

--- a/claude-pulse.ps1
+++ b/claude-pulse.ps1
@@ -10,28 +10,39 @@ $data = $inputJson | ConvertFrom-Json
 
 $cwd = $data.cwd
 $model_id = if ($data.model.id) { $data.model.id } else { "claude-sonnet-4-5-20250929" }
+$display_name = if ($data.model.display_name) { $data.model.display_name } else { "" }
 
 # Convert model ID to friendly name.
-# Ordered most-specific first: a shorter pattern (e.g. claude-opus-4*) would
-# otherwise shadow newer families like claude-opus-4-7.
-$model_name = switch -Wildcard ($model_id) {
-    "claude-opus-4-7*" { "Opus 4.7"; break }
-    "claude-opus-4-6*" { "Opus 4.6"; break }
-    "claude-opus-4*" { "Opus 4.5"; break }
-    "claude-sonnet-4-6*" { "Sonnet 4.6"; break }
-    "claude-sonnet-4-5*" { "Sonnet 4.5"; break }
-    "claude-sonnet-4*" { "Sonnet 4.5"; break }
-    "claude-haiku-4-5*" { "Haiku 4.5"; break }
-    "claude-4-5-haiku*" { "Haiku 4.5"; break }
-    "claude-haiku-3-5*" { "Haiku 3.5"; break }
-    "claude-3-5-haiku*" { "Haiku 3.5"; break }
-    "claude-sonnet-3-5*" { "Sonnet 3.5"; break }
-    "claude-3-5-sonnet*" { "Sonnet 3.5"; break }
-    "claude-opus-3*" { "Opus 3"; break }
-    "claude-3-opus*" { "Opus 3"; break }
-    "claude-sonnet-3-7*" { "Sonnet 3.7"; break }
-    "claude-3-7-sonnet*" { "Sonnet 3.7"; break }
-    default { "Claude" }
+#
+# The modern naming scheme is regular — claude-<family>-<major>-<minor> — so we
+# parse it generically and NEVER need a new branch per release (Opus 4.8, a
+# future Sonnet 5.0, etc. all "just work"). Only the irregular legacy IDs need
+# explicit rows, and anything unknown defers to Claude Code's own display_name.
+$model_name = $null
+if ($model_id -match '^claude-(opus|sonnet|haiku)-([0-9]+)-([0-9]{1,2})(?![0-9])') {
+    # The (?![0-9]) guard rejects 8-digit release dates (claude-opus-4-20250512),
+    # letting those fall through to the legacy table below.
+    $family = switch ($matches[1]) {
+        "opus"   { "Opus" }
+        "sonnet" { "Sonnet" }
+        "haiku"  { "Haiku" }
+    }
+    $model_name = "$family $($matches[2]).$($matches[3])"
+}
+
+if (-not $model_name) {
+    # Legacy / irregular IDs only — modern releases are handled above.
+    $model_name = switch -Wildcard ($model_id) {
+        "claude-opus-4*" { "Opus 4.5"; break }
+        "claude-sonnet-4*" { "Sonnet 4.5"; break }
+        "claude-4-5-haiku*" { "Haiku 4.5"; break }
+        "claude-3-5-haiku*" { "Haiku 3.5"; break }
+        "claude-3-5-sonnet*" { "Sonnet 3.5"; break }
+        "claude-opus-3*" { "Opus 3"; break }
+        "claude-3-opus*" { "Opus 3"; break }
+        "claude-3-7-sonnet*" { "Sonnet 3.7"; break }
+        default { if ($display_name) { $display_name } else { "Claude" } }
+    }
 }
 
 $context_limit = 200000

--- a/tests/test_statusline.sh
+++ b/tests/test_statusline.sh
@@ -22,6 +22,8 @@ assert_contains "$output" "test" "basic output has cwd"
 
 # test_model_detection: each model ID maps to correct name
 for pair in \
+    "claude-opus-4-8[1m]:Opus 4.8" \
+    "claude-opus-4-8:Opus 4.8" \
     "claude-opus-4-7-20260401:Opus 4.7" \
     "claude-opus-4-7:Opus 4.7" \
     "claude-opus-4-6-20250929:Opus 4.6" \
@@ -48,6 +50,19 @@ done
 out_opus47=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-7-20260401"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":1000000}}' | "$PULSE" 2>/dev/null)
 assert_not_contains "$out_opus47" "Opus 4.5" "Opus 4.7 does not fall through to Opus 4.5"
 assert_not_contains "$out_opus47" "Opus 4.6" "Opus 4.7 does not fall through to Opus 4.6"
+
+# Regression: Opus 4.8 (incl. [1m] context suffix) must not fall through to Opus 4.5.
+out_opus48=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-8[1m]"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":1000000}}' | "$PULSE" 2>/dev/null)
+assert_contains "$out_opus48" "Opus 4.8" "Opus 4.8 detected from claude-opus-4-8[1m]"
+assert_not_contains "$out_opus48" "Opus 4.5" "Opus 4.8 does not fall through to Opus 4.5"
+
+# Future-proofing: an unseen modern ID is parsed generically, not shown as bare "Claude".
+out_future=$(echo '{"cwd":"/test","model":{"id":"claude-sonnet-5-0-20270101"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | "$PULSE" 2>/dev/null)
+assert_contains "$out_future" "Sonnet 5.0" "unseen modern ID (sonnet-5-0) parsed generically"
+
+# Unknown / non-modern ID falls back to Claude Code's own model.display_name.
+out_dn=$(echo '{"cwd":"/test","model":{"id":"claude-neo-quantum","display_name":"Neo Quantum"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | "$PULSE" 2>/dev/null)
+assert_contains "$out_dn" "Neo Quantum" "unknown ID falls back to display_name"
 
 # test_context_limit_format: 200000 → "200k", 1000000 → "1M"
 out_200k=$(echo '{"cwd":"/test","model":{"id":"claude-opus-4-6"},"context_window":{"total_input_tokens":50000,"total_output_tokens":5000,"context_window_size":200000}}' | "$PULSE" 2>/dev/null)


### PR DESCRIPTION
## Problem

Opus 4.8 rendered as **"Opus 4.5"** — `claude-opus-4-8` fell through to the generic `claude-opus-4*` arm. The same class of bug recurs on every release (cf. #42 for 4.7 / Haiku 4.5).

## Fix: stop hardcoding each model

The modern ID scheme is regular — `claude-<family>-<major>-<minor>` — so it's parsed generically. New releases (Opus 4.8, a future Sonnet 5.0, …) are recognized with **zero code changes**.

- **Generic parser**: one regex (`^claude-(opus|sonnet|haiku)-([0-9]+)-([0-9]+)`) derives both the full name (`Opus 4.8`) and short form (`Op4.8`).
- **Date guard**: a ≤2-digit minor (bash) / `(?![0-9])` lookahead (PowerShell) stops 8-digit release dates like `claude-opus-4-20250512` from reading as "Opus 4.20250512".
- **Legacy table**: retained only for irregular IDs the parser can't handle — version-first names (`claude-3-5-sonnet`), no-minor base-4 models (`claude-opus-4*` → "Opus 4.5"), `claude-opus-3` → "Opus 3".
- **`display_name` fallback**: unknown IDs now defer to Claude Code's own `model.display_name` (already present in the statusline JSON) before falling back to literal "Claude" — so a brand-new *family* shows its real name.
- Mirrored in `claude-pulse.ps1`.

## Tests

+6 regression tests (`opus-4-8[1m]` suffix, generic `sonnet-5-0`, `display_name` fallback). **210/210 pass.**

## Version

Proposing **v3.2.0** (minor — new auto-detection capability, not just a fix). Version bump intentionally left out of this PR; it'll come with the `/release` flow after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)